### PR TITLE
Implement Observables and Filter Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ We welcome feedback and suggestions for new features! If you have an idea for a 
 - First version for event functions
 - Fixing unit test after import material components
 
-### v0.4.0 (2023-01-09)
+### v0.4.0 (2023-01-10)
 
 - Creation of dataservice with addItem, removeItem, getItem and updateItem for use in all the application
 - action stack elements to items array

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ GitHub Actions and Pages are configured to automatically build and deploy update
 
 ## Current Status
 
-My Project is currently in Filter Item Action implementation stage (v0.6.0) . Here is a list of the features that are currently implemented:
+My Project is currently in local storage stage (v0.7.0) . Here is a list of the features that are currently implemented:
 
 - First instalations and CD/CI integration
 - Component division
@@ -92,12 +92,12 @@ My Project is currently in Filter Item Action implementation stage (v0.6.0) . He
 - First Stable CSS version only for mobile
 - Stacker component action
 - Delete action in item component
+- Filter the item list
+- Checked action
 
 ## Future Steps
 
 There are several features and improvements that we plan to add to My Project in the future. Here is a list of some of the things that we are working on:
-
-- checked action item
 
 - css for desktop
 
@@ -105,7 +105,6 @@ There are several features and improvements that we plan to add to My Project in
 
 In addition to the features that we are currently working on, we also have a list of ideas for features that we may implement in the future. These features are not yet planned, but we are considering them for a future release:
 
-- implement localstorage to save the list modified
 - edit item descripction
 - add notes
 
@@ -141,3 +140,9 @@ We welcome feedback and suggestions for new features! If you have an idea for a 
 - Change the data-service implementing rxjs to get async data in list items
 - fix remove item method in items
 - changing unit test
+
+### v0.6.0 (2023-01-10)
+
+- Change the data-service to implement observables
+- Implement filter action
+- Change checkbox listener and update it in the service

--- a/src/app/components/filter/filter.component.spec.ts
+++ b/src/app/components/filter/filter.component.spec.ts
@@ -1,17 +1,19 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatOptionModule } from '@angular/material/core';
 import { FilterComponent } from './filter.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { DataService } from 'src/app/services/data-service';
 import { By } from '@angular/platform-browser';
 
 describe('FilterComponent', () => {
   let component: FilterComponent;
   let fixture: ComponentFixture<FilterComponent>;
+  let dataService: DataService;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
       declarations: [FilterComponent],
       imports: [
         MatSelectModule,
@@ -19,10 +21,20 @@ describe('FilterComponent', () => {
         MatOptionModule,
         BrowserAnimationsModule,
       ],
+      providers: [
+        {
+          provide: DataService,
+          useValue: {
+            updateFilter: jasmine.createSpy('updateFilter'),
+          },
+        },
+      ],
     }).compileComponents();
-
+  }));
+  beforeEach(() => {
     fixture = TestBed.createComponent(FilterComponent);
     component = fixture.componentInstance;
+    dataService = TestBed.inject(DataService);
     fixture.detectChanges();
   });
 
@@ -46,5 +58,17 @@ describe('FilterComponent', () => {
     selectNativeElement.dispatchEvent(new Event('selectionChange'));
     fixture.detectChanges();
     expect(component.onStateChange).toHaveBeenCalled();
+  });
+
+  it('should call dataService.updateFilter when onStateChange', () => {
+    component.selectedState = 'Checked';
+    component.onStateChange();
+    expect(dataService.updateFilter).toHaveBeenCalledWith('Checked');
+  });
+
+  it('should update selectedState when onStateChange', () => {
+    component.selectedState = 'Unchecked';
+    component.onStateChange();
+    expect(component.selectedState).toEqual('Unchecked');
   });
 });

--- a/src/app/components/filter/filter.component.ts
+++ b/src/app/components/filter/filter.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { DataService } from 'src/app/services/data-service';
+import { IFilter } from 'src/app/types/IFilter';
 
 @Component({
   selector: 'app-filter',
@@ -7,9 +9,11 @@ import { Component } from '@angular/core';
 })
 export class FilterComponent {
   states = ['All', 'Checked', 'Unchecked'];
-  selectedState: string = 'All';
-
+  selectedState: IFilter;
+  constructor(private dataService: DataService) {
+    this.selectedState = 'All';
+  }
   onStateChange() {
-    console.log(`State has changed: ${this.selectedState}`);
+    this.dataService.updateFilter(this.selectedState);
   }
 }

--- a/src/app/components/item/item.component.ts
+++ b/src/app/components/item/item.component.ts
@@ -8,14 +8,18 @@ import { DataService } from 'src/app/services/data-service';
 })
 export class ItemComponent {
   @Input() item: IItem;
+  checkboxValue: boolean;
   constructor(private dataService: DataService) {
     this.item = {
       checked: false,
       description: '',
       id: '0',
     };
+    this.checkboxValue = this.item.checked;
   }
-
+  onCheckboxChange() {
+    this.dataService.updateItem({ ...this.item, checked: this.checkboxValue });
+  }
   onRemoveItem(id: string): void {
     this.dataService.removeItem(id);
   }

--- a/src/app/components/item/item.component.ts
+++ b/src/app/components/item/item.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { IItem } from 'src/app/types/IItem';
 import { DataService } from 'src/app/services/data-service';
+
 @Component({
   selector: 'app-item',
   templateUrl: './item.component.html',
@@ -8,18 +9,14 @@ import { DataService } from 'src/app/services/data-service';
 })
 export class ItemComponent {
   @Input() item: IItem;
-  checkboxValue: boolean;
   constructor(private dataService: DataService) {
     this.item = {
       checked: false,
       description: '',
       id: '0',
     };
-    this.checkboxValue = this.item.checked;
   }
-  onCheckboxChange() {
-    this.dataService.updateItem({ ...this.item, checked: this.checkboxValue });
-  }
+
   onRemoveItem(id: string): void {
     this.dataService.removeItem(id);
   }

--- a/src/app/components/list/list.component.html
+++ b/src/app/components/list/list.component.html
@@ -1,12 +1,10 @@
 <div class="list" data-test="list">
-  <ng-container *ngIf="items$ | async as items">
-    <h2 data-test="list__h2">All</h2>
-    <ul>
-      <li *ngFor="let item of items">
-        <app-item [item]="item"></app-item>
-      </li>
-    </ul>
-  </ng-container>
+  <h2 data-test="list__h2">All</h2>
+  <ul>
+    <li *ngFor="let item of items$">
+      <app-item [item]="item"></app-item>
+    </li>
+  </ul>
 </div>
 
 <!--  -->

--- a/src/app/components/list/list.component.ts
+++ b/src/app/components/list/list.component.ts
@@ -10,11 +10,14 @@ import { Observable } from 'rxjs';
   styleUrls: ['./list.component.scss'],
 })
 export class ListComponent {
-  items$: Observable<IItem[]>;
+  items$: IItem[] = [];
   // Keep the DataService private
-  private dataService: DataService;
-  constructor(dataService: DataService) {
+  constructor(private dataService: DataService) {
     this.dataService = dataService;
-    this.items$ = this.dataService.items$;
+  }
+  ngOnInit() {
+    this.dataService.getFilteredItems$().subscribe((items) => {
+      this.items$ = items;
+    });
   }
 }

--- a/src/app/services/data-service.spec.ts
+++ b/src/app/services/data-service.spec.ts
@@ -66,4 +66,65 @@ describe('DataService', () => {
     service.updateItem(modifiedItem);
     expect(service.getItem(item1.id)).toEqual(modifiedItem);
   });
+
+  it('should return the correct item', () => {
+    const item = { id: '1', description: 'Test Item', checked: true };
+    service.itemsSubject.next([item]);
+    const result = service.getItem('1');
+    expect(result).toEqual(item);
+  });
+
+  it('should return default value if item not found', () => {
+    const item = { id: '1', description: 'Test Item', checked: true };
+    service.itemsSubject.next([item]);
+    const result = service.getItem('2');
+    expect(result).toEqual({ id: '', description: '', checked: false });
+  });
+
+  it('should update the item correctly', () => {
+    const item = { id: '1', description: 'Test Item', checked: true };
+    const modifiedItem = {
+      id: '1',
+      description: 'Modified Item',
+      checked: false,
+    };
+    service.itemsSubject.next([item]);
+    service.updateItem(modifiedItem);
+    expect(service.itemsSubject.value).toEqual([modifiedItem]);
+  });
+
+  it('should call filter.next with correct filter value', () => {
+    const filterValue = 'Checked';
+    spyOn(service.filter, 'next');
+    service.updateFilter(filterValue);
+    expect(service.filter.next).toHaveBeenCalledWith(filterValue);
+  });
+
+  it('should return filtered items as an observable', () => {
+    const items = [
+      { id: '1', description: 'Test Item 1', checked: true },
+      { id: '2', description: 'Test Item 2', checked: false },
+      { id: '3', description: 'Test Item 3', checked: true },
+    ];
+    service.itemsSubject.next(items);
+    service.updateFilter('Checked');
+    const filteredItems$ = service.getFilteredItems$();
+    filteredItems$.subscribe((result) => {
+      expect(result).toEqual([items[0], items[2]]);
+    });
+  });
+
+  it('should return unchecked items when filter is set to Unchecked', () => {
+    const items = [
+      { id: '1', description: 'Test Item 1', checked: true },
+      { id: '2', description: 'Test Item 2', checked: false },
+      { id: '3', description: 'Test Item 3', checked: true },
+    ];
+    service.itemsSubject.next(items);
+    service.updateFilter('Unchecked');
+    const filteredItems$ = service.getFilteredItems$();
+    filteredItems$.subscribe((result) => {
+      expect(result).toEqual([items[1]]);
+    });
+  });
 });

--- a/src/app/types/IFilter.ts
+++ b/src/app/types/IFilter.ts
@@ -1,0 +1,2 @@
+type IFilter = 'All' | 'Checked' | 'Unchecked';
+export { IFilter };


### PR DESCRIPTION
This PR implements observables in the data service and adds the ability to filter items. The checkbox listener is also updated to update the item's checked property in the service directly.

DataService was refactored to use observables for managing items and filter state.
The updateFilter method added to the service, to update the filter state.
getFilteredItems$ method added to the service, to get the filtered items based on the current filter state.
Checkbox listener updated in the ItemComponent to directly update the item's checked property in the service when the checkbox is clicked.
Changelog
v0.6.0 (2023-01-10)
Change the data-service to implement observables
Implement filter action
Change checkbox listener and update it in the service
This PR bring a big improvement in the overall functionality and performance, and it makes the code more readable and maintainable.